### PR TITLE
Wrap errors thrown by StateMachine

### DIFF
--- a/src/grpc.js
+++ b/src/grpc.js
@@ -3,7 +3,12 @@ import StateMachine from 'javascript-state-machine'
 import createDebug from 'debug'
 import lndconnect from 'lndconnect'
 import { status } from '@grpc/grpc-js'
-import { grpcSslCipherSuites, validateHost } from './utils'
+import {
+  grpcSslCipherSuites,
+  validateHost,
+  onInvalidTransition,
+  onPendingTransition
+} from './utils'
 import { WalletUnlocker, Lightning, Autopilot, ChainNotifier, Invoices, Router, Signer, WalletKit } from './services'
 import registry from './registry'
 
@@ -46,7 +51,13 @@ class LndGrpc extends EventEmitter {
         onBeforeActivateLightning: this.onBeforeActivateLightning.bind(this),
         onBeforeDisconnect: this.onBeforeDisconnect.bind(this),
         onAfterDisconnect: this.onAfterDisconnect.bind(this),
+        onInvalidTransition,
+        onPendingTransition,
       },
+
+      onInvalidTransition(transition, from, to) {
+        throw Object.assign(new Error(`transition is invalid in current state`), { transition, from, to })
+      }
     })
 
     // Define services.

--- a/src/service.js
+++ b/src/service.js
@@ -13,6 +13,8 @@ import {
   createMacaroonCreds,
   getLatestProtoVersion,
   getProtoDir,
+  onInvalidTransition,
+  onPendingTransition,
 } from './utils'
 import registry from './registry'
 
@@ -42,7 +44,9 @@ class Service extends EventEmitter {
         onAfterConnect: this.onAfterConnect.bind(this),
         onBeforeDisconnect: this.onBeforeDisconnect.bind(this),
         onAfterDisconnect: this.onAfterDisconnect.bind(this),
-      },
+        onInvalidTransition,
+        onPendingTransition,
+      }
     })
 
     this.useMacaroon = true

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,5 +6,6 @@ export grpcSslCipherSuites from './grpcSslCipherSuites'
 export promisifiedCall from './promisifiedCall'
 export validateHost from './validateHost'
 export waitForFile from './waitForFile'
+export { onInvalidTransition, onPendingTransition } from './stateMachineErrorHandlers'
 
 export * from './proto'

--- a/src/utils/stateMachineErrorHandlers.js
+++ b/src/utils/stateMachineErrorHandlers.js
@@ -1,0 +1,12 @@
+// The default error handler of StateMachine do not throw regular js Errors with stack traces.
+// https://github.com/jakesgordon/javascript-state-machine/blob/master/docs/error-handling.md#invalid-transitions
+// Usage:
+// new StateMachine({ ... methods: [ ..., onPendingTransition, onInvalidTransition ] })
+
+export const onPendingTransition = (transition, from, to) => {
+  throw Object.assign(new Error('transition already in progress'), { transition, from, to });
+};
+
+export const onInvalidTransition = (transition, from, to) => {
+  throw Object.assign(new Error('transition is invalid in current state'), { transition, from, to });
+};

--- a/test/grpc.test.js
+++ b/test/grpc.test.js
@@ -59,7 +59,7 @@ test('ready -> connect (active)', async t => {
 })
 
 test('locked -> connect', async t => {
-  t.plan(1)
+  t.plan(2)
   const grpc = new LndGrpc(grpcOptions)
   sinon.stub(grpc, 'determineWalletState').resolves('WALLET_STATE_LOCKED')
   await grpc.connect()
@@ -67,11 +67,12 @@ test('locked -> connect', async t => {
     await grpc.connect()
   } catch (e) {
     t.equal(e.message, 'transition is invalid in current state', 'should throw an error if called from locked state')
+    t.ok(e.stack, 'error has stack')
   }
 })
 
 test('active -> connect', async t => {
-  t.plan(1)
+  t.plan(2)
   const grpc = new LndGrpc(grpcOptions)
   sinon.stub(grpc, 'determineWalletState').resolves('WALLET_STATE_ACTIVE')
   await grpc.connect()
@@ -79,6 +80,7 @@ test('active -> connect', async t => {
     await grpc.connect()
   } catch (e) {
     t.equal(e.message, 'transition is invalid in current state', 'should throw an error if called from active state')
+    t.ok(e.stack, 'error has stack')
   }
 })
 
@@ -101,11 +103,12 @@ test('active -> disconnect', async t => {
 })
 
 test('ready -> disconnect', async t => {
-  t.plan(1)
+  t.plan(2)
   try {
     const grpc = new LndGrpc(grpcOptions)
     await grpc.disconnect()
   } catch (e) {
     t.equal(e.message, 'transition is invalid in current state', 'should throw an error if called from ready state')
+    t.ok(e.stack, 'error has stack')
   }
 })

--- a/test/helpers/lnd.js
+++ b/test/helpers/lnd.js
@@ -3,7 +3,6 @@ import { join, resolve } from 'path'
 import { spawn } from 'child_process'
 import rimraf from 'rimraf'
 import { extensions } from 'lnd-binary'
-import split2 from 'split2'
 
 export const lndBinPath = resolve('node_modules/lnd-binary/vendor', 'lnd' + extensions.getBinaryFileExtension())
 


### PR DESCRIPTION
I noticed that some errors were thrown without full stack trace and
narrowed it down to javascript-state-machine. As it turns out, the
library throws plain objects instead of proper error instances:

https://github.com/jakesgordon/javascript-state-machine/blob/0d60357/src/util/exception.js

This change wraps the errors thrown by the fsm transition methods in
proper `Error` instances. Now call sites will get the full error
stack.

To reproduce:

```
» node -e $'
const Grpc = require("./dist")
const grpc = new Grpc({});
grpc.disconnect()
  .catch((e) => console.error(e));
'
```

Before:
```
{ message: 'transition is invalid in current state',
  transition: 'disconnect',
  from: 'ready',
  to: undefined,
  current: 'ready' }
```

After:
```
{ Error: transition is invalid in current state
    at StateMachine.args [as disconnect] (/home/bitgotto/src/BitGo/node-lnd-grpc/src/grpc.js:59:31)
    at LndGrpc.disconnect (/home/bitgotto/src/BitGo/node-lnd-grpc/src/grpc.js:128:20)
    at [eval]:4:6
    at ContextifyScript.Script.runInThisContext (vm.js:50:33)
    at Object.runInThisContext (vm.js:139:38)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (module.js:653:30)
    at evalScript (bootstrap_node.js:479:27)
    at startup (bootstrap_node.js:180:9)
    at bootstrap_node.js:625:3
  message: 'transition is invalid in current state',
  transition: 'disconnect',
  from: 'ready',
  to: undefined,
  current: 'ready' }
```