### PR TITLE
Fix fsm proxies

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -56,22 +56,22 @@ class Service extends EventEmitter {
   // ------------------------------------
 
   is(...args) {
-    return this.fsm.is(args)
+    return this.fsm.is(...args)
   }
   can(...args) {
-    return this.fsm.can(args)
+    return this.fsm.can(...args)
   }
   observe(...args) {
-    return this.fsm.observe(args)
+    return this.fsm.observe(...args)
   }
   get state() {
     return this.fsm.state
   }
   connect(...args) {
-    return this.fsm.connect(args)
+    return this.fsm.connect(...args)
   }
   disconnect(...args) {
-    return this.fsm.disconnect(args)
+    return this.fsm.disconnect(...args)
   }
 
   // ------------------------------------


### PR DESCRIPTION
Do not pass the `args` as array, but actually call function with args
spread out.

It probably worked because the single-element array got stringified
later.