### PR TITLE
fix: don't auto subscribe to ln grpc after wallet unlock

### DIFF
--- a/src/grpc.js
+++ b/src/grpc.js
@@ -3,12 +3,7 @@ import StateMachine from 'javascript-state-machine'
 import createDebug from 'debug'
 import lndconnect from 'lndconnect'
 import { status } from '@grpc/grpc-js'
-import {
-  grpcSslCipherSuites,
-  validateHost,
-  onInvalidTransition,
-  onPendingTransition
-} from './utils'
+import { grpcSslCipherSuites, validateHost, onInvalidTransition, onPendingTransition } from './utils'
 import { WalletUnlocker, Lightning, Autopilot, ChainNotifier, Invoices, Router, Signer, WalletKit } from './services'
 import registry from './registry'
 
@@ -57,7 +52,7 @@ class LndGrpc extends EventEmitter {
 
       onInvalidTransition(transition, from, to) {
         throw Object.assign(new Error(`transition is invalid in current state`), { transition, from, to })
-      }
+      },
     })
 
     // Define services.
@@ -147,8 +142,6 @@ class LndGrpc extends EventEmitter {
    * Connect to and activate the wallet unlocker api.
    */
   async onBeforeActivateWalletUnlocker() {
-    // Set up a listener that connects to the lightning interface as soon as the wallet has been unlocked.
-    this.services.WalletUnlocker.on('unlocked', this.activateLightning.bind(this))
     if (this.services.WalletUnlocker.can('connect')) {
       await this.services.WalletUnlocker.connect()
     }
@@ -215,7 +208,7 @@ class LndGrpc extends EventEmitter {
     let walletState
     try {
       await this.services.WalletUnlocker.connect()
-      // Call the unlockWallet methpd with a missing password argument.
+      // Call the unlockWallet method with a missing password argument.
       // This is a way of probing the api to determine it's state.
       await this.services.WalletUnlocker.unlockWallet()
     } catch (error) {

--- a/test/lnd.initWallet.test.js
+++ b/test/lnd.initWallet.test.js
@@ -15,10 +15,11 @@ test('initWallet:test', async t => {
   try {
     grpc = new LndGrpc(grpcOptions)
     await grpc.connect()
-    grpc.services.WalletUnlocker.initWallet({
+    await grpc.services.WalletUnlocker.initWallet({
       wallet_password: Buffer.from('password'),
       cipher_seed_mnemonic: seed,
     })
+    grpc.activateLightning()
     grpc.once('active', async () => {
       t.equal(grpc.state, 'active', 'should emit "active" event and be in active state')
     })

--- a/test/lnd.unlockWallet.test.js
+++ b/test/lnd.unlockWallet.test.js
@@ -19,6 +19,7 @@ test('unlockWallet:test', async t => {
       wallet_password: Buffer.from('password'),
       cipher_seed_mnemonic: seed,
     })
+    grpc.activateLightning()
     grpc.once('active', async () => {
       try {
         await grpc.disconnect()
@@ -26,9 +27,11 @@ test('unlockWallet:test', async t => {
         lndProcess = await spawnLnd()
         grpc = new LndGrpc(grpcOptions)
         await grpc.connect()
-        grpc.services.WalletUnlocker.unlockWallet({
+
+        await grpc.services.WalletUnlocker.unlockWallet({
           wallet_password: Buffer.from('password'),
         })
+        grpc.activateLightning()
         grpc.once('active', async () => {
           t.equal(grpc.state, 'active', 'should emit "active" event and be in active state')
         })


### PR DESCRIPTION
BREAKING CHANGE: 
Currently, errors that are thrown by 
```
  this.services.WalletUnlocker.on('unlocked', this.activateLightning.bind(this))
```
in `grpc.onBeforeActivateWalletUnlocker` are swallowed. 
To avoid this `grpc.connect` no longer automatically `this.activateLightning` on `WalletUnlocker.unlocked` event