### PR TITLE
fix: handle case where lnd is started with noseedbackup

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -16,19 +16,11 @@ import {
   getProtoDir,
   onInvalidTransition,
   onPendingTransition,
+  CONNECT_WAIT_TIMEOUT,
+  FILE_WAIT_TIMEOUT,
+  MAX_SESSION_MEMORY,
 } from './utils'
 import registry from './registry'
-
-// Time (in seconds) to wait for a connection to be established.
-const CONNECT_WAIT_TIMEOUT = 10 * 1000
-
-// Time (in ms) to wait for a cert/macaroon file to become present.
-const FILE_WAIT_TIMEOUT = 10 * 1000
-
-// Default value for `maxSessionMemory` is 10 which is quite low for the lnd gRPC server, which can stream a lot of data
-// in a short space of time. We increase this to prevent `NGHTTP2_ENHANCE_YOUR_CALM` errors from http2 streams.
-// See https://nodejs.org/api/http2.html#http2_http2_connect_authority_options_listener.
-const MAX_SESSION_MEMORY = 50
 
 const DEFAULT_OPTIONS = {
   grpcOptions,
@@ -187,7 +179,7 @@ class Service extends EventEmitter {
       this.service = new rpcService(host, creds)
 
       // Wait up to CONNECT_WAIT_TIMEOUT seconds for the gRPC connection to be established.
-      await promisifiedCall(this.service, this.service.waitForReady, getDeadline(CONNECT_WAIT_TIMEOUT / 1000))
+      await promisifiedCall(this.service, this.service.waitForReady, getDeadline(CONNECT_WAIT_TIMEOUT))
 
       // Set up helper methods to proxy service methods.
       this.wrapAsync(rpcService.service)

--- a/src/service.js
+++ b/src/service.js
@@ -19,11 +19,11 @@ import {
 } from './utils'
 import registry from './registry'
 
-// Time (in ms) to wait for a connection to be established.
-const CONNECT_WAIT_TIMEOUT = 10000
+// Time (in seconds) to wait for a connection to be established.
+const CONNECT_WAIT_TIMEOUT = 10 * 1000
 
 // Time (in ms) to wait for a cert/macaroon file to become present.
-const FILE_WAIT_TIMEOUT = 10000
+const FILE_WAIT_TIMEOUT = 10 * 1000
 
 // Default value for `maxSessionMemory` is 10 which is quite low for the lnd gRPC server, which can stream a lot of data
 // in a short space of time. We increase this to prevent `NGHTTP2_ENHANCE_YOUR_CALM` errors from http2 streams.
@@ -214,15 +214,15 @@ class Service extends EventEmitter {
       }
       // If this method is a stream, bind it to the service instance as is.
       if (method.requestStream || method.responseStream) {
-        this[originalName] = (payload = {}) => {
-          this.debug(`Calling ${this.serviceName}.${originalName} with payload: %o`, payload)
-          return this.service[originalName].bind(this.service).call()
+        this[originalName] = (payload = {}, options = {}) => {
+          this.debug(`Calling ${this.serviceName}.${originalName} with: %o`, { payload, options })
+          return this.service[originalName].bind(this.service).call(payload, options)
         }
       }
       // Otherwise, promisify and bind to the service instance.
-      this[originalName] = (payload = {}) => {
-        this.debug(`Calling ${this.serviceName}.${originalName} with payload: %o`, payload)
-        return promisifiedCall(this.service, this.service[originalName], payload)
+      this[originalName] = (payload = {}, options = {}) => {
+        this.debug(`Calling ${this.serviceName}.${originalName} with: %o`, { payload, options })
+        return promisifiedCall(this.service, this.service[originalName], payload, options)
       }
     })
   }

--- a/src/services/lightning.js
+++ b/src/services/lightning.js
@@ -1,8 +1,5 @@
-import { getClosestProtoVersion, getLatestProtoVersion, getDeadline } from '../utils'
+import { getClosestProtoVersion, getLatestProtoVersion, getDeadline, PROBE_TIMEOUT } from '../utils'
 import Service from '../service'
-
-// Time (in ms) to wait for call to getInfo to complete.
-const GET_INFO_WAIT_TIMEOUT = 5 * 1000
 
 /**
  * Lightning service controller.
@@ -24,7 +21,7 @@ class Lightning extends Service {
     await this.establishConnection()
 
     // Once connected, make a call to getInfo in order to determine the api version.
-    const info = await this.getInfo({}, { deadline: getDeadline(GET_INFO_WAIT_TIMEOUT / 1000) })
+    const info = await this.getInfo({}, { deadline: getDeadline(PROBE_TIMEOUT) })
     this.debug('Connected to Lightning gRPC: %O', info)
 
     // Determine most relevant proto version based on the api info.

--- a/src/services/lightning.js
+++ b/src/services/lightning.js
@@ -2,7 +2,7 @@ import { getClosestProtoVersion, getLatestProtoVersion, getDeadline } from '../u
 import Service from '../service'
 
 // Time (in ms) to wait for call to getInfo to complete.
-const GET_INFO_WAIT_TIMEOUT = 2 * 1000
+const GET_INFO_WAIT_TIMEOUT = 5 * 1000
 
 /**
  * Lightning service controller.

--- a/src/services/lightning.js
+++ b/src/services/lightning.js
@@ -1,5 +1,8 @@
-import { getClosestProtoVersion, getLatestProtoVersion } from '../utils'
+import { getClosestProtoVersion, getLatestProtoVersion, getDeadline } from '../utils'
 import Service from '../service'
+
+// Time (in ms) to wait for call to getInfo to complete.
+const GET_INFO_WAIT_TIMEOUT = 2 * 1000
 
 /**
  * Lightning service controller.
@@ -21,7 +24,7 @@ class Lightning extends Service {
     await this.establishConnection()
 
     // Once connected, make a call to getInfo in order to determine the api version.
-    const info = await this.getInfo()
+    const info = await this.getInfo({}, { deadline: getDeadline(GET_INFO_WAIT_TIMEOUT / 1000) })
     this.debug('Connected to Lightning gRPC: %O', info)
 
     // Determine most relevant proto version based on the api info.

--- a/src/services/walletUnlocker.js
+++ b/src/services/walletUnlocker.js
@@ -11,16 +11,16 @@ class WalletUnlocker extends Service {
     this.useMacaroon = false
   }
 
-  async initWallet(payload = {}) {
-    this.debug(`Calling ${this.serviceName}.initWallet with payload: %o`, payload)
-    const res = await promisifiedCall(this.service, this.service.initWallet, payload)
+  async initWallet(payload = {}, options = {}) {
+    this.debug(`Calling ${this.serviceName}.initWallet with payload: %o`, { payload, options })
+    const res = await promisifiedCall(this.service, this.service.initWallet, payload, options)
     this.emit('unlocked')
     return res
   }
 
-  async unlockWallet(payload = {}) {
-    this.debug(`Calling ${this.serviceName}.unlockWallet with payload: %o`, payload)
-    const res = await promisifiedCall(this.service, this.service.unlockWallet, payload)
+  async unlockWallet(payload = {}, options = {}) {
+    this.debug(`Calling ${this.serviceName}.unlockWallet with payload: %o`, { payload, options })
+    const res = await promisifiedCall(this.service, this.service.unlockWallet, payload, options)
     this.emit('unlocked')
     return res
   }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -7,5 +7,5 @@ export promisifiedCall from './promisifiedCall'
 export validateHost from './validateHost'
 export waitForFile from './waitForFile'
 export { onInvalidTransition, onPendingTransition } from './stateMachineErrorHandlers'
-
+export * from './constants'
 export * from './proto'

--- a/src/utils/promisifiedCall.js
+++ b/src/utils/promisifiedCall.js
@@ -6,6 +6,6 @@ import { promisify } from 'util'
  * @param {*} method
  * @param {*} args
  */
-export default function promisifiedCall(thisArg, method, args) {
-  return promisify(method).call(thisArg, args)
+export default function promisifiedCall(thisArg, method, ...args) {
+  return promisify(method).call(thisArg, ...args)
 }

--- a/test/helpers/lnd.js
+++ b/test/helpers/lnd.js
@@ -3,6 +3,7 @@ import { join, resolve } from 'path'
 import { spawn } from 'child_process'
 import rimraf from 'rimraf'
 import { extensions } from 'lnd-binary'
+import split2 from 'split2'
 
 export const lndBinPath = resolve('node_modules/lnd-binary/vendor', 'lnd' + extensions.getBinaryFileExtension())
 
@@ -19,17 +20,19 @@ export const spawnLnd = (options = {}) => {
     '--bitcoin.testnet',
     '--bitcoin.node=neutrino',
     '--neutrino.connect=testnet3-btcd.zaphq.io',
+    // '--noseedbackup',
+    // '--notls=1',
   ])
 
-  // // Listen for when neutrino prints data to stderr.
-  // process.stderr.pipe(split2()).on('data', line => {
-  //   console.error(line)
-  // })
-  //
-  // // Listen for when neutrino prints data to stdout.
-  // process.stdout.pipe(split2()).on('data', line => {
-  //   console.info(line)
-  // })
+  // Listen for when neutrino prints data to stderr.
+  process.stderr.pipe(split2()).on('data', line => {
+    console.error(line)
+  })
+
+  // Listen for when neutrino prints data to stdout.
+  process.stdout.pipe(split2()).on('data', line => {
+    console.info(line)
+  })
 
   return process
 }


### PR DESCRIPTION
Switch from calling `WalletUnlocker.unlockWallet` to `Lightning.getInfo` when attempting to determine the wallet state. This resolves issues with some lnd versions in which the `WalletUnlocker` interface does not respond properly if the wallet is already unlocked.

This is specifically in ref to https://github.com/LN-Zap/zap-desktop/issues/2535