### PR TITLE
fix: do not promisify streams

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -212,9 +212,11 @@ class Service extends EventEmitter {
         }
       }
       // Otherwise, promisify and bind to the service instance.
-      this[originalName] = (payload = {}, options = {}) => {
-        this.debug(`Calling ${this.serviceName}.${originalName} with: %o`, { payload, options })
-        return promisifiedCall(this.service, this.service[originalName], payload, options)
+      else {
+        this[originalName] = (payload = {}, options = {}) => {
+          this.debug(`Calling ${this.serviceName}.${originalName} with: %o`, { payload, options })
+          return promisifiedCall(this.service, this.service[originalName], payload, options)
+        }
       }
     })
   }

--- a/test/grpc.test.js
+++ b/test/grpc.test.js
@@ -2,7 +2,6 @@ import { spawn } from 'child_process'
 import test from 'tape-promise/tape'
 import sinon from 'sinon'
 import { join } from 'path'
-import { status, ClientReadableStream } from '@grpc/grpc-js'
 import LndGrpc from '../src'
 
 const hostname = 'testnet3'
@@ -112,33 +111,4 @@ test('ready -> disconnect', async t => {
     t.equal(e.message, 'transition is invalid in current state', 'should throw an error if called from ready state')
     t.ok(e.stack, 'error has stack')
   }
-})
-
-test('Lightning.invoices', async t => {
-  t.plan(3)
-  let grpc, call
-  try {
-    grpc = new LndGrpc(grpcOptions)
-    await grpc.connect()
-    call = grpc.services.Lightning.subscribeInvoices()
-    t.equal(
-      call.constructor.name,
-      'ClientReadableStreamImpl',
-      'Lightning.subscribeInvoices() should return a ClientReadableStreamImpl instance',
-    )
-    const promise = new Promise(async (resolve, reject) => {
-      call.on('error', function(error) {
-        t.equal(error.code, status.CANCELLED, 'call.cancel() should cancel an invoice subscription stream')
-        if (error.code === status.CANCELLED) {
-          return resolve()
-        }
-      })
-    })
-    await grpc.services.Lightning.addInvoice({ value: 100 })
-    await promise
-  } catch (e) {
-    t.equal(e.message, 'permission denied', 'should not allow creating an invoice with a readonly macaroon')
-  }
-  call && call.cancel()
-  await grpc.disconnect()
 })

--- a/test/grpc.test.js
+++ b/test/grpc.test.js
@@ -2,6 +2,7 @@ import { spawn } from 'child_process'
 import test from 'tape-promise/tape'
 import sinon from 'sinon'
 import { join } from 'path'
+import { status, ClientReadableStream } from '@grpc/grpc-js'
 import LndGrpc from '../src'
 
 const hostname = 'testnet3'
@@ -111,4 +112,33 @@ test('ready -> disconnect', async t => {
     t.equal(e.message, 'transition is invalid in current state', 'should throw an error if called from ready state')
     t.ok(e.stack, 'error has stack')
   }
+})
+
+test('Lightning.invoices', async t => {
+  t.plan(3)
+  let grpc, call
+  try {
+    grpc = new LndGrpc(grpcOptions)
+    await grpc.connect()
+    call = grpc.services.Lightning.subscribeInvoices()
+    t.equal(
+      call.constructor.name,
+      'ClientReadableStreamImpl',
+      'Lightning.subscribeInvoices() should return a ClientReadableStreamImpl instance',
+    )
+    const promise = new Promise(async (resolve, reject) => {
+      call.on('error', function(error) {
+        t.equal(error.code, status.CANCELLED, 'call.cancel() should cancel an invoice subscription stream')
+        if (error.code === status.CANCELLED) {
+          return resolve()
+        }
+      })
+    })
+    await grpc.services.Lightning.addInvoice({ value: 100 })
+    await promise
+  } catch (e) {
+    t.equal(e.message, 'permission denied', 'should not allow creating an invoice with a readonly macaroon')
+  }
+  call && call.cancel()
+  await grpc.disconnect()
 })

--- a/test/helpers/lnd.js
+++ b/test/helpers/lnd.js
@@ -4,6 +4,9 @@ import { spawn } from 'child_process'
 import rimraf from 'rimraf'
 import { extensions } from 'lnd-binary'
 import split2 from 'split2'
+import debug from 'debug'
+
+const log = debug(`lnrpc:test`)
 
 export const lndBinPath = resolve('node_modules/lnd-binary/vendor', 'lnd' + extensions.getBinaryFileExtension())
 
@@ -26,12 +29,12 @@ export const spawnLnd = (options = {}) => {
 
   // Listen for when neutrino prints data to stderr.
   process.stderr.pipe(split2()).on('data', line => {
-    console.error(line)
+    log(line)
   })
 
   // Listen for when neutrino prints data to stdout.
   process.stdout.pipe(split2()).on('data', line => {
-    console.info(line)
+    log(line)
   })
 
   return process

--- a/test/servives.Lightning.test.js
+++ b/test/servives.Lightning.test.js
@@ -1,0 +1,41 @@
+import test from 'tape-promise/tape'
+import { join } from 'path'
+import { status } from '@grpc/grpc-js'
+import LndGrpc from '../src'
+
+const hostname = 'testnet3'
+
+const host = `${hostname}-lnd.zaphq.io:10009`
+const cert = join(__dirname, `fixtures/${hostname}`, 'tls.cert')
+const macaroon = join(__dirname, `fixtures/${hostname}`, 'readonly.macaroon')
+
+const grpcOptions = { host, cert, macaroon }
+
+test('Lightning.invoices', async t => {
+  t.plan(3)
+  let grpc, call
+  try {
+    grpc = new LndGrpc(grpcOptions)
+    await grpc.connect()
+    call = grpc.services.Lightning.subscribeInvoices()
+    t.equal(
+      call.constructor.name,
+      'ClientReadableStreamImpl',
+      'Lightning.subscribeInvoices() should return a ClientReadableStreamImpl instance',
+    )
+    const promise = new Promise(async resolve => {
+      call.on('error', function(error) {
+        t.equal(error.code, status.CANCELLED, 'call.cancel() should cancel an invoice subscription stream')
+        if (error.code === status.CANCELLED) {
+          return resolve()
+        }
+      })
+    })
+    await grpc.services.Lightning.addInvoice({ value: 100 })
+    await promise
+  } catch (e) {
+    t.equal(e.message, 'permission denied', 'should not allow creating an invoice with a readonly macaroon')
+  }
+  call && call.cancel()
+  await grpc.disconnect()
+})


### PR DESCRIPTION
Subscription methods (eg subscribeInvoices) should not be promisified as they are synchronous methods that return a `ClientReadableStreamImpl`.

fix #63