### PR TITLE
fix: propagate errors in case of timeout

### DIFF
--- a/src/utils/promiseTimeout.js
+++ b/src/utils/promiseTimeout.js
@@ -18,5 +18,5 @@ export default function(ms, promise, message = 'Timed out') {
     return value
   }
   // Returns a race between our timeout and the passed in promise
-  return Promise.race([promise, timeout]).then(clearTimer, clearTimer)
+  return Promise.race([promise, timeout]).finally(clearTimer)
 }


### PR DESCRIPTION
Errors from promiseTimeout are being swallowed by the `catch` handler and as a result they are not being propagated to the caller. This prevents callers from being able to properly react to errors in the grpc connection process.