### PR TITLE
fix(grpc): handle correctly SERVER_ACTIVE wallet state

### DIFF
--- a/src/grpc.js
+++ b/src/grpc.js
@@ -154,6 +154,7 @@ class LndGrpc extends EventEmitter {
         case 'UNLOCKED': // Do nothing.
           break
         case 'RPC_ACTIVE':
+        case 'SERVER_ACTIVE':
           walletState = WALLET_STATE_ACTIVE
           break
       }
@@ -235,9 +236,9 @@ class LndGrpc extends EventEmitter {
   async onBeforeActivateLightning() {
     const { Lightning, WalletUnlocker } = this.services
 
-    // await for RPC_ACTIVE state before interacting if needed
+    // await for RPC_ACTIVE or SERVER_ACTIVE state before interacting if needed
     if (this.isStateServiceAvailable) {
-      await this.checkWalletState('RPC_ACTIVE')
+      await this.checkWalletState(['RPC_ACTIVE', 'SERVER_ACTIVE'])
     }
 
     // Disconnect wallet unlocker if its connected.


### PR DESCRIPTION
Hello,

This PR fixes https://github.com/LN-Zap/zap-desktop/issues/3775 and all the other related issues

What was happening:
with LND 0.14.0 a new wallet state was introduced (`SERVER_ACTIVE`) that was not correctly handled.
LND 0.14.0 release note: https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.14.0.md?plain=1#L174
LND commit: https://github.com/lightningnetwork/lnd/pull/5637/commits/f5bac969e377a4fc187aca0da337ac015b748715

LND when unlocked is returning this state and zap-desktop was trying to unlock the wallet.

Thanks for your amazing work with zap!

Edit: The error `Cannot read property 'unlockWallet' of null` is because when wallet is in this new state, the UnlockWallet grpc is disabled