### PR TITLE
docs(readme): note potential loss of precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Under the hood we use the [`grpc-js`](https://github.com/grpc/grpc-node/tree/mas
   oneofs: true,
 }
 ```
+(Note: when dealing with channel IDs and other fields that can exceed JavaScript's Number.MAX_SAFE_INTEGER, loss of precision can occur. This can be avoided by using `longs: String` on the above gRPC options and dealing with `String`s instead of `Number`s.)
 
 These settings can be overridden by passing `grpcOptions` to the constructor. Custom settings will be merged in with the above defaults.
 


### PR DESCRIPTION
**tl;dr**: gRPC by default converts uint64 (and similar types) to JS's Number, which can result to loss of precision when exceeding JavaScript's Number.MAX_SAFE_INTEGER (2^53 - 1). Using `LndGrpc({ grpcOptions: { longs: String }})` solves this with some arguable side-effects.

This was a bit of a rabbit hole, so posting this in part for future rabbit-holers to save them some time.

- I was getting weird `channel_id`s results
- looked into https://github.com/lightningnetwork/lnd and noticed the proto field was uint64
- the underlining grpc lib unfortunately converts uint64 to Number, that can cause loss of precision
- lnd's proto field was lacking `[jstype = JS_STRING]` that can help
- checked for other uint64 fields and they are countless
- "polluting" the whole code-base with ` [jstype = JS_STRING]` doesn't seem ideal
- thankfully `node-lnd-grpc` allows the use of custom gRPC Options that can solve this:

```js
LndGrpc({
  grpcOptions: {
     longs: String
  }
})
```
I'm not making a PR for changing the defaults of this package since it will probably break things for people, since it will return strings for a wide range of fields from amounts, timeouts, fee rates and a ton more.
